### PR TITLE
Add tests

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -16,12 +16,23 @@ steps:
     command:
       - make lint-plugin
 
-  # TODO: Add some unit tests!
-  # - label: ":lint-roller::buildkite: Test Plugin"
-  #   command:
-  #     - make test-plugin
+  - label: ":bash: Unit Test Bash"
+    command:
+      - make test-bash
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":buildkite::vault: Run Plugin - Login"
-    command: echo 'Hello World'
+  - label: ":lint-roller::buildkite: Test Plugin"
+    command:
+      - make test-plugin
+
+  - label: ":buildkite::vault: Validate Plugin Behavior"
+    command:
+      - .buildkite/scripts/environment-hook-validation.sh
     plugins:
       - "grapl-security/vault-login#${BUILDKITE_COMMIT}":
+      - improbable-eng/metahook#v0.4.1:
+          pre-exit: .buildkite/scripts/pre-exit-hook-validation.sh

--- a/.buildkite/scripts/BUILD
+++ b/.buildkite/scripts/BUILD
@@ -1,0 +1,1 @@
+shell_library()

--- a/.buildkite/scripts/environment-hook-validation.sh
+++ b/.buildkite/scripts/environment-hook-validation.sh
@@ -15,10 +15,9 @@ if [ -z "${VAULT_TOKEN}" ]; then
 fi
 
 # Just do something that we know we can do with the Vault token we've got.
-# TODO: Consider granting these tokens the ability to just run `vault
-# token lookup`
-# shellcheck disable=SC2034
-if ! token=$(vault kv get -field=TOOLCHAIN_AUTH_TOKEN secret/buildkite/env/vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN); then
-    echo "Failed to use token to retrieve a secret!"
+if ! vault token lookup > /dev/null; then
+    echo "Failed to interact with Vault using VAULT_TOKEN!"
     exit 1
+else
+    echo "Successfully interacted with Vault using VAULT_TOKEN"
 fi

--- a/.buildkite/scripts/environment-hook-validation.sh
+++ b/.buildkite/scripts/environment-hook-validation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This script is to validate that the plugin's environment hook did
+# the right thing; namely, drop a VAULT_TOKEN into the environment
+# that we can use to do things with.
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/vault.sh"
+
+if [ -z "${VAULT_TOKEN}" ]; then
+    echo "VAULT_TOKEN should be present in the environment after invoking the vault-login plugin, but it was not!"
+    exit 1
+fi
+
+# Just do something that we know we can do with the Vault token we've got.
+# TODO: Consider granting these tokens the ability to just run `vault
+# token lookup`
+# shellcheck disable=SC2034
+if ! token=$(vault kv get -field=TOOLCHAIN_AUTH_TOKEN secret/buildkite/env/vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN); then
+    echo "Failed to use token to retrieve a secret!"
+    exit 1
+fi

--- a/.buildkite/scripts/pre-exit-hook-validation.sh
+++ b/.buildkite/scripts/pre-exit-hook-validation.sh
@@ -11,11 +11,9 @@ set -euo pipefail
 # shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/../../lib/vault.sh"
 
-if output=$(vault kv get -field=TOOLCHAIN_AUTH_TOKEN secret/buildkite/env/vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN 2>&1); then
+if vault token lookup > /dev/null; then
     echo "Token should have been revoked, but we made a successful call to Vault!"
-    # echo "${output}"
     exit 1
 else
     echo "Failed to make a call to Vault with a revoked token, as expected"
-    echo "${output}"
 fi

--- a/.buildkite/scripts/pre-exit-hook-validation.sh
+++ b/.buildkite/scripts/pre-exit-hook-validation.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script is intended to run *after* the plugin's post-exit script
+# (which we can do with the metahook plugin) to verify that the Vault
+# token has indeed been revoked. If that's the case, we shouldn't be
+# able to make a call.
+#
+# See https://github.com/improbable-eng/metahook-buildkite-plugin
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/vault.sh"
+
+if output=$(vault kv get -field=TOOLCHAIN_AUTH_TOKEN secret/buildkite/env/vault-login-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN 2>&1); then
+    echo "Token should have been revoked, but we made a successful call to Vault!"
+    # echo "${output}"
+    exit 1
+else
+    echo "Failed to make a call to Vault with a revoked token, as expected"
+    echo "${output}"
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 COMPOSE_USER=$(shell id -u):$(shell id -g)
 
+.DEFAULT_GOAL=all
+
 # Linting
 ########################################################################
 
@@ -28,7 +30,11 @@ format-bash:
 ########################################################################
 
 .PHONY: test
-test: test-plugin
+test: test-bash test-plugin
+
+.PHONY: test-bash
+test-bash:
+	./pants test ::
 
 .PHONY: test-plugin
 test-plugin:

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,1 +1,7 @@
 shell_library()
+
+shunit2_tests(
+    name="tests",
+    # Currently using relative imports for tests, which aren't visible to Pants
+    dependencies=[":lib"]
+)

--- a/lib/vault.sh
+++ b/lib/vault.sh
@@ -8,28 +8,59 @@ readonly default_tag="latest"
 # commands being used
 readonly image="${BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_VAULT_LOGIN_TAG:-${default_tag}}"
 
-# VAULT_ADDR="https://vault-cluster.private.vault.b3b89729-5226-4b15-8c8a-b42572e88e7c.aws.hashicorp.cloud:8200"
-# readonly VAULT_ADDR
-# export VAULT_ADDR
-# VAULT_NAMESPACE="admin/buildkite"
-# readonly VAULT_NAMESPACE
-# export VAULT_NAMESPACE
-
-# --cap-add IPC_LOCK is required to prevent silly error messages from
-# polluting stdout
-#
-# Rather than that, just don't use --interactive / -tty
-
-# --tty adds in the ANSI control characters we don't want
-# --interactive seems control the stderr/stdout conflation
+# Wrap up the invocation of a Vault container image to alleviate the
+# need to have a Vault binary installed on the Buildkite agent machine
+# already. Scripts can just source this file and then call `vault`
+# like normal.
 vault() {
+    # We're passing our environment variables like this to make
+    # testing a bit easier. In particular, having visibility into the
+    # values used for VAULT_ADDR and VAULT_NAMESPACE makes it easy to
+    # confirm that the proper values are being used (taking into
+    # account default values, overrides, etc.)
+    #
+    # Conditionally adding them also facilitates some unit testing.
+    env_args=()
+
+    if [ -n "${VAULT_ADDR:-}" ]; then
+        env_args+=("--env=VAULT_ADDR=${VAULT_ADDR}")
+    fi
+
+    if [ -n "${VAULT_NAMESPACE:-}" ]; then
+        env_args+=("--env=VAULT_NAMESPACE=${VAULT_NAMESPACE}")
+    fi
+
+    # We don't need to pass the VAULT_TOKEN by value (it should also
+    # be treated like a secret, whereas VAULT_ADDR and VAULT_NAMESPACE
+    # don't).
+    if [ -n "${VAULT_TOKEN:-}" ]; then
+        env_args+=("--env=VAULT_TOKEN")
+    fi
+
+    # It is important to not use `--interactive` and `--tty` in this
+    # Docker invocation (particularly `--tty`), as that can result in
+    # getting stdout and stderr streams mixed in the output of this
+    # command, as well as getting embedded ANSI codes, which can cause
+    # subsequent Vault commands to fail (Vault doesn't like ANSI codes
+    # in its tokens, for instance).
+
+    # NOTE: The particularly ugly expansion of `env_args` here is to work
+    # around the fact that we currently have Bash 4.2 on our Buildkite
+    # agents, where expanding empty arrays in the presence of `set -u`
+    # will raise an unbound variable error. With Bash 4.4+, this is no
+    # longer the case, allowing us to use the more sensible
+    # "${env_args[@]}"
+    #
+    # See the following for further background (most concretely, the
+    # final link):
+    # - https://stackoverflow.com/a/61551944
+    # - https://gist.github.com/dimo414/2fb052d230654cc0c25e9e41a9651ebe
+    # - https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?id=3ba697465bc74fab513a26dea700cc82e9f4724e#n878
     docker run \
         --init \
         --rm \
         --cap-add IPC_LOCK \
-        --env=VAULT_ADDR \
-        --env=VAULT_NAMESPACE \
-        --env=VAULT_TOKEN \
+        ${env_args[@]+"${env_args[@]}"} \
         -- \
         "${image}" "$@"
 }

--- a/lib/vault_test.sh
+++ b/lib/vault_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/vault.sh"
+}
+
+test_vault_stdout_is_clean() {
+    # This command will fail, which is expected. It will emit a
+    # combination of stderr and stdout, however. If the Docker run is
+    # not configured properly w/r/t interactivity, TTY, and
+    # capabilities, the standard output stream *of the container run*
+    # will contain a mixture of the standard output and standard error
+    # streams of the *vault process* within the container. We do not
+    # want this.
+    #
+    # The standard error stream would look like this, FYI:
+    #    [INFO]  proxy environment: http_proxy="" https_proxy="" no_proxy=""
+    output="$(vault server)"
+    assertEquals "The output should only contain stdout, not stderr" \
+        "A storage backend must be specified" \
+        "${output}"
+}
+
+test_vault_stdout_contains_no_ANSI_codes() {
+    # This command will fail, which is expected. If the container is
+    # run with a TTY (i.e., `--tty`) attached, however, it will
+    # contain ANSI codes in the output, which we do not want. *That*
+    # is the main focus of this test.
+    output="$(vault server)"
+    expanded_output="$(cat --show-nonprinting --show-tabs <<< "${output}")"
+
+    # These will be different if the output contains ANSI characters
+    # (or anything else it shouldn't!)
+    assertEquals "The output of the vault command should not contain ANSI control characters" \
+        "${output}" \
+        "${expanded_output}"
+}

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+
+load "$BATS_PATH/load.bash"
+
+# Uncomment to enable stub debugging
+# export DOCKER_STUB_DEBUG=/dev/tty
+
+setup() {
+    # TODO: These two variable values duplicate stuff from vault.sh;
+    # split things up better
+    export DEFAULT_IMAGE=hashicorp/vault
+    export DEFAULT_TAG=latest
+
+    export BUILDKITE_AGENT_META_DATA_QUEUE=default
+
+    export VAULT_ADDR=default.vault.mycompany.com:8200
+    export VAULT_NAMESPACE=default_namespace
+}
+
+teardown() {
+    unset VAULT_ADDR
+    unset VAULT_NAMESPACE
+    unset BUILDKITE_AGENT_META_DATA_QUEUE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_TAG
+}
+
+@test "VAULT_ADDR and VAULT_NAMESPACE are accepted in the absence of explicit overrides" {
+    [ -n "${VAULT_ADDR}" ]
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS
+    [ -n "${VAULT_NAMESPACE}" ]
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "VAULT_ADDR is overridden in the presence of an explicitly configured address" {
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS=override.vault.mycompany.com:8200
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=override.vault.mycompany.com:8200 --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "Missing both VAULT_ADDR and explicitly configured address is a failure" {
+    unset VAULT_ADDR
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS
+
+    run "${PWD}/hooks/environment"
+    assert_output --partial "Could not find 'VAULT_ADDR' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS' was not specified!"
+
+    assert_failure
+
+}
+
+@test "VAULT_NAMESPACE is overridden in the presence of an explicitly configured namespace" {
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE=override_namespace
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=override_namespace -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "Missing VAULT_NAMESPACE and an explicitly configured namespace is a failure" {
+    unset VAULT_NAMESPACE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
+
+    run "${PWD}/hooks/environment"
+    assert_output --partial "Could not find 'VAULT_NAMESPACE' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE' was not specified!"
+
+    assert_failure
+}
+
+@test "The image can be overridden" {
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE=mycompany/vault
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "The image tag can be overridden" {
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "Image and tag can be overridden simultaneously" {
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE=mycompany/vault
+    export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+}
+
+@test "A queue name with a slash is converted to the proper authentication role name" {
+    export BUILDKITE_AGENT_META_DATA_QUEUE=default/testing
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default-testing : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+
+    run "${PWD}/hooks/environment"
+    assert_success
+
+    unstub docker
+
+}

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load "$BATS_PATH/load.bash"
+
+# Uncomment to enable stub debugging
+# export DOCKER_STUB_DEBUG=/dev/tty
+
+setup() {
+    # TODO: These two variable values duplicate stuff from vault.sh;
+    # split things up better
+    export DEFAULT_IMAGE=hashicorp/vault
+    export DEFAULT_TAG=latest
+
+    export BUILDKITE_AGENT_META_DATA_QUEUE=default
+
+    export VAULT_ADDR=default.vault.mycompany.com:8200
+    export VAULT_NAMESPACE=default_namespace
+}
+
+teardown() {
+    unset VAULT_ADDR
+    unset VAULT_NAMESPACE
+    unset BUILDKITE_AGENT_META_DATA_QUEUE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE
+    unset BUILDKITE_PLUGIN_VAULT_LOGIN_TAG
+}
+
+@test "When missing a VAULT_TOKEN, do nothing" {
+    unset VAULT_TOKEN
+
+    run "${PWD}/hooks/pre-exit"
+
+    assert_output --partial "No 'VAULT_TOKEN' found in the environment; skipping revocation"
+    assert_success
+}
+
+@test "When VAULT_TOKEN is present, revoke the token" {
+    export VAULT_TOKEN="THIS_IS_A_PRETEND_VAULT_TOKEN"
+
+    stub docker \
+         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} --env=VAULT_TOKEN -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} token revoke -self : echo 'Success! Revoked token (if it existed)'"
+
+    run "${PWD}/hooks/pre-exit"
+
+    assert_output --partial "Success! Revoked token (if it existed)"
+    assert_success
+
+    unstub docker
+}


### PR DESCRIPTION
Adds a lot of BATS tests for the Buildkite Plugin tester, as well as
some unit tests for the Bash scripts. Additionally, adds more
affirmative testing of both the environment and pre-exit hooks in the
context of an *actual* invocation of the plugin in Buildkite.

Also modifies some of the code to make it more testable.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>