### PR TITLE
Remove `--cap-add IPC_LOCK` option from Docker invocation

### DIFF
--- a/lib/vault.sh
+++ b/lib/vault.sh
@@ -20,7 +20,12 @@ vault() {
     # account default values, overrides, etc.)
     #
     # Conditionally adding them also facilitates some unit testing.
-    env_args=()
+    #
+    # SKIP_SETCAP prevents the printing of an error message about not
+    # being able to add the IPC_LOCK capability... we don't need to
+    # grant this capability for our usecases, and we don't need to
+    # print that "scary" message in our Buildkite logs.
+    env_args=("--env=SKIP_SETCAP=true")
 
     if [ -n "${VAULT_ADDR:-}" ]; then
         env_args+=("--env=VAULT_ADDR=${VAULT_ADDR}")
@@ -59,7 +64,6 @@ vault() {
     docker run \
         --init \
         --rm \
-        --cap-add IPC_LOCK \
         ${env_args[@]+"${env_args[@]}"} \
         -- \
         "${image}" "$@"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -34,7 +34,7 @@ teardown() {
     unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -46,7 +46,7 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS=override.vault.mycompany.com:8200
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=override.vault.mycompany.com:8200 --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=override.vault.mycompany.com:8200 --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -69,7 +69,7 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE=override_namespace
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=override_namespace -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=override_namespace -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -91,7 +91,7 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE=mycompany/vault
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -103,7 +103,7 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -116,7 +116,7 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -128,7 +128,7 @@ teardown() {
     export BUILDKITE_AGENT_META_DATA_QUEUE=default/testing
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default-testing : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default-testing : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -40,7 +40,7 @@ teardown() {
     export VAULT_TOKEN="THIS_IS_A_PRETEND_VAULT_TOKEN"
 
     stub docker \
-         "run --init --rm --cap-add IPC_LOCK --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} --env=VAULT_TOKEN -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} token revoke -self : echo 'Success! Revoked token (if it existed)'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} --env=VAULT_TOKEN -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} token revoke -self : echo 'Success! Revoked token (if it existed)'"
 
     run "${PWD}/hooks/pre-exit"
 


### PR DESCRIPTION
This isn't actually needed for our purposes, so there's no reason to
add it.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>