### PR TITLE
Modify Vault authentication role name resolution logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ fail.
 
 At the moment, this plugin is chiefly concerned with Grapl's needs,
 and may not be sufficiently generalized or flexible enough for all
-uses.
+uses. For instance, it assumes the use of AWS, and also makes some
+assumptions about the name of the role to authenticate with.
 
 ## Example
+
+In general, this will be how you'll interact with the plugin the
+majority of the time (here, the `address` and `namespace` have been
+set in the environment already, since those will generally be the same
+across your pipelines):
 
 ```yml
 steps:
@@ -33,6 +39,8 @@ steps:
     plugins:
       - grapl-security/vault-login#v0.1.0
 ```
+
+You can override many of the built-in defaults, or be very explicit:
 
 ```yml
 steps:
@@ -44,7 +52,31 @@ steps:
         address: https://vault.mycompany.com:8200
         namespace: admin/buildkite
 ```
+
+You can sidestep the internal logic for determining the authentication
+role name from the Buildkite queue name if you really need to:
+
+```yml
+steps:
+  - command: make test
+    plugins:
+      - grapl-security/vault-login#v0.1.0:
+        auth_role: super_special_auth_role
+```
+
 ## Configuration
+
+### address (optional, string)
+
+The address of the Vault server to access. If not set, falls back to
+`VAULT_ADDR` in the environment. If `VAULT_ADDR` is not set either,
+the plugin fails with an error.
+
+### auth_role (optional, string)
+
+The name of the Vault AWS role to authenticate as. If not specified,
+uses (Grapl-specific) logic to generate the role name from the
+Buildkite agent queue name.
 
 ### image (optional, string)
 
@@ -54,23 +86,17 @@ entrypoint.
 
 Defaults to `hashicorp/vault`.
 
-### tag (optional, string)
-
-The container image tag the plugin uses.
-
-Defaults to `latest`.
-
-### address (optional, string)
-
-The address of the Vault server to access. If not set, falls back to
-`VAULT_ADDR` in the environment. If `VAULT_ADDR` is not set either,
-the plugin fails with an error.
-
 ### namespace (optional, string)
 
 The Vault namespace to access. If not set, falls back to
 `VAULT_NAMESPACE` in the environment. If `VAULT_NAMESPACE` is not set
 either, the plugin fails with an error.
+
+### tag (optional, string)
+
+The container image tag the plugin uses.
+
+Defaults to `latest`.
 
 ## Building
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -33,13 +33,21 @@ if [ -z "${VAULT_NAMESPACE:-}" ]; then
     exit 1
 fi
 
+# Resolve Authentication Role
+########################################################################
+if [ -n "${BUILDKITE_PLUGIN_VAULT_LOGIN_AUTH_ROLE:-}" ]; then
+    vault_authentication_role="${BUILDKITE_PLUGIN_VAULT_LOGIN_AUTH_ROLE}"
+else
+    vault_authentication_role="$(aws_auth_role)"
+fi
+
 echo "--- :vault: Login to ${VAULT_ADDR}"
 echo "Using Docker image: ${image}"
 echo "VAULT_ADDR=${VAULT_ADDR}"
 echo "VAULT_NAMESPACE=${VAULT_NAMESPACE}"
 # TODO: add in the `header_value` as well
 
-VAULT_TOKEN=$(vault login -method=aws -token-only role="$(aws_auth_role)")
+VAULT_TOKEN=$(vault login -method=aws -token-only role="${vault_authentication_role}")
 
 # NOTE: Making this readonly somehow breaks the post-exit hook; the
 #       token is somehow missing.

--- a/hooks/environment
+++ b/hooks/environment
@@ -7,8 +7,16 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/vault.sh"
 
 # Our roles in Vault map to our queue names. We need to tweak it a
 # bit, though, in order to obey Vault's naming rules.
+
+# Our roles in Vault map roughly to our Buildkite queues, but we must
+# account for their different names in our different Pulumi
+# stacks. "production" stack queues just use their regular name (e.g.,
+# "default", while other stack's queues are modified with their stack
+# name, e.g. "default/testing".
+#
+# We need to chop off the `/` and anything that follows.
 aws_auth_role() {
-    tr '/' '-' <<< "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    awk 'BEGIN { FS = "/"}; {print $1}' <<< "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 }
 
 # Resolve Vault address

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,12 @@ author: https://github.com/grapl-security
 requirements: ["docker"]
 configuration:
   properties:
+    auth_role:
+      description: |
+        The name of the authentication role to use. If not specified,
+        internal (Grapl-specific) logic will be used to generate a
+        role name from the Buildkite agent queue name.
+      type: string
     image:
       description: The `vault` image to use; defaults to `hashicorp/vault`.
       type: string

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -129,7 +129,7 @@ teardown() {
     export BUILDKITE_AGENT_META_DATA_QUEUE=default/testing
 
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default-testing : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success


### PR DESCRIPTION
This PR does two things:
- Allows users to optionally specify an authentication role name, bypassing our internal naming logic
- Modifies our internal naming logic to deal with a new way of modeling our authentication roles

Read the individual commit messages for further background, as well as the updated documentation in the README.