### PR TITLE
Add fancy logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ across your pipelines):
 steps:
   - command: make test
     plugins:
-      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-login#v0.1.1
 ```
 
 You can override many of the built-in defaults, or be very explicit:
@@ -46,7 +46,7 @@ You can override many of the built-in defaults, or be very explicit:
 steps:
   - command: make test
     plugins:
-      - grapl-security/vault-login#v0.1.0:
+      - grapl-security/vault-login#v0.1.1:
         image: vault
         tag: 1.8.4
         address: https://vault.mycompany.com:8200
@@ -60,7 +60,7 @@ role name from the Buildkite queue name if you really need to:
 steps:
   - command: make test
     plugins:
-      - grapl-security/vault-login#v0.1.0:
+      - grapl-security/vault-login#v0.1.1:
         auth_role: super_special_auth_role
 ```
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 # shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/vault.sh"
 
 # Our roles in Vault map to our queue names. We need to tweak it a
@@ -26,8 +28,7 @@ if [ -n "${BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS:-}" ]; then
     export VAULT_ADDR
 fi
 if [ -z "${VAULT_ADDR:-}" ]; then
-    echo "--- :skull_and_crossbones: Could not find 'VAULT_ADDR' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS' was not specified!"
-    exit 1
+    raise_error "Could not find 'VAULT_ADDR' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS' was not specified!"
 fi
 
 # Resolve Vault namespace
@@ -37,8 +38,7 @@ if [ -n "${BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE:-}" ]; then
     export VAULT_NAMESPACE
 fi
 if [ -z "${VAULT_NAMESPACE:-}" ]; then
-    echo "--- :skull_and_crossbones: Could not find 'VAULT_NAMESPACE' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE' was not specified!"
-    exit 1
+    raise_error "Could not find 'VAULT_NAMESPACE' in the environment, and 'BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE' was not specified!"
 fi
 
 # Resolve Authentication Role
@@ -55,7 +55,7 @@ echo "VAULT_ADDR=${VAULT_ADDR}"
 echo "VAULT_NAMESPACE=${VAULT_NAMESPACE}"
 # TODO: add in the `header_value` as well
 
-VAULT_TOKEN=$(vault login -method=aws -token-only role="${vault_authentication_role}")
+VAULT_TOKEN=$(log_and_run vault login -method=aws -token-only role="${vault_authentication_role}")
 
 # NOTE: Making this readonly somehow breaks the post-exit hook; the
 #       token is somehow missing.

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Various logging functions and helpers to make logging nice.
+
+# ANSI Formatting Codes
+########################################################################
+# Because who wants to remember all those fiddly details?
+
+# CSI = "Control Sequence Introducer"
+CSI="\e["
+END=m
+
+NORMAL=0
+BOLD=1
+
+WHITE=37
+
+RESET="${CSI}${NORMAL}${END}"
+
+function _bold_color() {
+    color="${1}"
+    shift
+    echo "${CSI}${BOLD};${color}${END}${*}${RESET}"
+}
+
+function bright_white() {
+    _bold_color "${WHITE}" "${@}"
+}
+
+# Logging
+########################################################################
+# NOTE: All logs get sent to standard error
+
+function log() {
+    echo -e "${@}" >&2
+}
+
+# Handy for logging the exact command to be run, and then running it
+function log_and_run() {
+    log ❯❯ "$(bright_white "$(printf "%q " "${@}")")"
+    "$@"
+}
+
+raise_error() {
+    log "--- :rotating_light:" "${@}"
+    # Yes, these numbers are correct :/
+    if [ -z "${BASH_SOURCE[2]:-}" ]; then
+        # If we're calling raise_error from a script directly, we'll
+        # have a shorter call stack.
+        log "Failed in ${FUNCNAME[1]}() at [${BASH_SOURCE[1]}:${BASH_LINENO[0]}]"
+    else
+        log "Failed in ${FUNCNAME[1]}() at [${BASH_SOURCE[1]}:${BASH_LINENO[0]}], called from [${BASH_SOURCE[2]}:${BASH_LINENO[1]}]"
+    fi
+    exit 1
+}


### PR DESCRIPTION
This is in keeping with our logging practices in our other Buildkite
plugins. The main concrete change here is that we'll log the exact
`vault` invocation that we use, which is handy for visibility,
debugging, etc.

We also bump the version in our documentation examples.