### PR TITLE
Retry failed login attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ steps:
   - command: make test
     plugins:
       - grapl-security/vault-login#v0.1.1:
-        image: vault
-        tag: 1.8.4
-        address: https://vault.mycompany.com:8200
-        namespace: admin/buildkite
+          image: vault
+          tag: 1.8.4
+          address: https://vault.mycompany.com:8200
+          namespace: admin/buildkite
 ```
 
 You can sidestep the internal logic for determining the authentication
@@ -61,24 +61,24 @@ steps:
   - command: make test
     plugins:
       - grapl-security/vault-login#v0.1.1:
-        auth_role: super_special_auth_role
+          auth_role: super_special_auth_role
 ```
 
 ## Configuration
 
-### address (optional, string)
+### `address` (optional, string)
 
 The address of the Vault server to access. If not set, falls back to
 `VAULT_ADDR` in the environment. If `VAULT_ADDR` is not set either,
 the plugin fails with an error.
 
-### auth_role (optional, string)
+### `auth_role` (optional, string)
 
 The name of the Vault AWS role to authenticate as. If not specified,
 uses (Grapl-specific) logic to generate the role name from the
 Buildkite agent queue name.
 
-### image (optional, string)
+### `image` (optional, string)
 
 The container image with the Codecov Uploader binary that the plugin
 uses. Any container used should have the `codecov` binary as its
@@ -86,13 +86,13 @@ entrypoint.
 
 Defaults to `hashicorp/vault`.
 
-### namespace (optional, string)
+### `namespace` (optional, string)
 
 The Vault namespace to access. If not set, falls back to
 `VAULT_NAMESPACE` in the environment. If `VAULT_NAMESPACE` is not set
 either, the plugin fails with an error.
 
-### tag (optional, string)
+### `tag` (optional, string)
 
 The container image tag the plugin uses.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ steps:
           auth_role: super_special_auth_role
 ```
 
+Failed attempts to login can be retried, which comes in handy if you
+experience transient network issues. By default, the plugin attempts 3
+times, waiting 5 seconds between each attempt, but these values are
+both configurable:
+
+```yml
+steps:
+  - command: make test
+    plugins:
+      - grapl-security/vault-login#v0.1.1:
+          attempt_count: 5
+          attempt_wait_seconds: 10
+```
+
+Setting `attempt_count` to `1` effectively disables the retry logic.
+
 ## Configuration
 
 ### `address` (optional, string)
@@ -97,6 +113,21 @@ either, the plugin fails with an error.
 The container image tag the plugin uses.
 
 Defaults to `latest`.
+
+### `attempt_count` (optional, integer)
+
+The number of times to attempt to login to Vault before giving
+up.
+
+Defaults to `3`.
+
+You can disable retries by setting this to `1`.
+
+### `attempt_wait_seconds` (optional, integer)
+
+The number of seconds to wait between each retry attempt.
+
+Defaults to `5`.
 
 ## Building
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -49,13 +49,51 @@ else
     vault_authentication_role="$(aws_auth_role)"
 fi
 
+# Resolve Retry Configuration
+########################################################################
+readonly default_attempt_count=3
+readonly attempt_count="${BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_COUNT:-${default_attempt_count}}"
+
+readonly default_attempt_wait_seconds=5
+readonly attempt_wait_seconds="${BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_WAIT_SECONDS:-${default_attempt_wait_seconds}}"
+
+if (("${attempt_count}" < 1)); then
+    raise_error "Must provide a positive value for attempt_count!"
+fi
+
+if (("${attempt_wait_seconds}" < 1)); then
+    raise_error "Must provide a positive value for attempt_wait_seconds!"
+fi
+
 echo "--- :vault: Login to ${VAULT_ADDR}"
 echo "Using Docker image: ${image}"
 echo "VAULT_ADDR=${VAULT_ADDR}"
 echo "VAULT_NAMESPACE=${VAULT_NAMESPACE}"
 # TODO: add in the `header_value` as well
 
-VAULT_TOKEN=$(log_and_run vault login -method=aws -token-only role="${vault_authentication_role}")
+for i in $(seq 1 "${attempt_count}"); do
+    if ! VAULT_TOKEN="$(log_and_run vault login -method=aws -token-only role="${vault_authentication_role}")"; then
+        if [ "${i}" = "${attempt_count}" ]; then
+            if (("${attempt_count}" == 1)); then
+                # Because "Failed to login 1 times!" is silly
+                raise_error "Failed to login!"
+            else
+                raise_error "Failed to login ${attempt_count} times!"
+            fi
+        else
+            if (("${attempt_wait_seconds}" == 1)); then
+                # Because "will try again in 1 seconds" is silly
+                units="second"
+            else
+                units="seconds"
+            fi
+            log "Failed login attempt ${i}/${attempt_count}; will try again in ${attempt_wait_seconds} ${units}"
+            sleep "${attempt_wait_seconds}"
+        fi
+    else
+        break
+    fi
+done
 
 # NOTE: Making this readonly somehow breaks the post-exit hook; the
 #       token is somehow missing.

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,15 +12,32 @@ configuration:
         role name from the Buildkite agent queue name.
       type: string
     image:
-      description: The `vault` image to use; defaults to `hashicorp/vault`.
+      description: |
+        The `vault` image to use; defaults to `hashicorp/vault`.
       type: string
     tag:
-      description: The `vault` image tag to use; defaults to `latest`
+      description: |
+        The `vault` image tag to use; defaults to `latest`.
       type: string
     address:
-      description: The address of the Vault server to interact with. Should include protocol, server, and port (corresponds to 'VAULT_ADDR').
+      description: |
+        The address of the Vault server to interact with. Should
+        include protocol, server, and port (corresponds to
+        'VAULT_ADDR').
       type: string
     namespace:
-      description: The Vault namespace to interact with (corresponds to 'VAULT_NAMESPACE').
+      description: |
+        The Vault namespace to interact with (corresponds to
+        'VAULT_NAMESPACE').
       type: string
-  additionalProperties: false
+    attempt_count:
+      description: |
+        The number of times to attempt to login to Vault before giving
+        up. Defaults to 3.
+      type: integer
+    attempt_wait_seconds:
+      description: |
+        The number of seconds to wait between each retry
+        attempt. Defaults to 5.
+      type: integer
+    additionalProperties: false


### PR DESCRIPTION
Having become tired of failing jobs due to transient inabilities to
login to HCP Vault, I decided to add automatic retry logic. Now, we'll
make a total of 3 `vault login` attempts, waiting 5 seconds between
each attempt. If all attempts fail, the entire hook fails.

Both the number of login attempts and the number of seconds between
attempts are customizable with the `attempt_count` and
`attempt_wait_seconds` plugin parameters.