### PR TITLE
Add an `always-pull` option

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -40,3 +40,12 @@ steps:
       - "grapl-security/vault-login#${BUILDKITE_COMMIT}":
       - improbable-eng/metahook#v0.4.1:
           pre-exit: .buildkite/scripts/pre-exit-hook-validation.sh
+
+  - label: ":buildkite::vault: Validate Plugin Behavior with pull"
+    command:
+      - .buildkite/scripts/environment-hook-validation.sh
+    plugins:
+      - "grapl-security/vault-login#${BUILDKITE_COMMIT}":
+          always-pull: true
+      - improbable-eng/metahook#v0.4.1:
+          pre-exit: .buildkite/scripts/pre-exit-hook-validation.sh

--- a/README.md
+++ b/README.md
@@ -82,38 +82,29 @@ Setting `attempt_count` to `1` effectively disables the retry logic.
 
 ## Configuration
 
-### `address` (optional, string)
+### `vault` Flags
+
+#### `address` (optional, string)
 
 The address of the Vault server to access. If not set, falls back to
 `VAULT_ADDR` in the environment. If `VAULT_ADDR` is not set either,
 the plugin fails with an error.
 
-### `auth_role` (optional, string)
+#### `auth_role` (optional, string)
 
 The name of the Vault AWS role to authenticate as. If not specified,
 uses (Grapl-specific) logic to generate the role name from the
 Buildkite agent queue name.
 
-### `image` (optional, string)
-
-The container image with the `vault` binary that the plugin uses. Any
-container used should have the `vault` binary as its entrypoint.
-
-Defaults to `hashicorp/vault`.
-
-### `namespace` (optional, string)
+#### `namespace` (optional, string)
 
 The Vault namespace to access. If not set, falls back to
 `VAULT_NAMESPACE` in the environment. If `VAULT_NAMESPACE` is not set
 either, the plugin fails with an error.
 
-### `tag` (optional, string)
+### Retry Configuration
 
-The container image tag the plugin uses.
-
-Defaults to `latest`.
-
-### `attempt_count` (optional, integer)
+#### `attempt_count` (optional, integer)
 
 The number of times to attempt to login to Vault before giving
 up.
@@ -122,11 +113,34 @@ Defaults to `3`.
 
 You can disable retries by setting this to `1`.
 
-### `attempt_wait_seconds` (optional, integer)
+#### `attempt_wait_seconds` (optional, integer)
 
 The number of seconds to wait between each retry attempt.
 
 Defaults to `5`.
+
+### Container Image Configuration
+
+#### `image` (optional, string)
+
+The container image with the `vault` binary that the plugin uses. Any
+container used should have the `vault` binary as its entrypoint.
+
+Defaults to `hashicorp/vault`.
+
+#### `tag` (optional, string)
+
+The container image tag the plugin uses.
+
+Defaults to `latest`.
+
+#### `always_pull` (optional, boolean)
+
+Whether or not to perform an explicit `docker pull` of the configured
+image before running. Useful when using the `latest` tag to ensure you
+are always using the _actual_ latest image.
+
+Defaults to `false`.
 
 ## Building
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -65,6 +65,8 @@ if (("${attempt_wait_seconds}" < 1)); then
     raise_error "Must provide a positive value for attempt_wait_seconds!"
 fi
 
+maybe_pull_image
+
 echo "--- :vault: Login to ${VAULT_ADDR}"
 echo "Using Docker image: ${image}"
 echo "VAULT_ADDR=${VAULT_ADDR}"

--- a/lib/vault_test.sh
+++ b/lib/vault_test.sh
@@ -36,3 +36,25 @@ test_vault_stdout_contains_no_ANSI_codes() {
         "${output}" \
         "${expanded_output}"
 }
+
+test_explicit_pull() {
+    output="$(BUILDKITE_PLUGIN_VAULT_LOGIN_ALWAYS_PULL=1 maybe_pull_image)"
+    assertContains "${output}" "latest: Pulling from hashicorp/vault"
+}
+
+test_no_explicit_pull() {
+    output="$(
+        unset BUILDKITE_PLUGIN_VAULT_LOGIN_ALWAYS_PULL
+        maybe_pull_image
+    )"
+    assertEquals "" "${output}"
+}
+
+test_synonyms_for_always_pull_activation() {
+    for value in "true" "on" "1"; do
+        output="$(BUILDKITE_PLUGIN_VAULT_LOGIN_ALWAYS_PULL=${value} maybe_pull_image)"
+        assertContains "Expected '${value}' to enable 'always-pull' option" \
+            "${output}" \
+            "latest: Pulling from hashicorp/vault"
+    done
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,8 @@
 name: Vault Login
 description: Log into a Hashicorp Vault server
 author: https://github.com/grapl-security
-requirements: ["docker"]
+requirements:
+  - "docker"
 configuration:
   properties:
     auth_role:
@@ -19,6 +20,15 @@ configuration:
       description: |
         The `vault` image tag to use; defaults to `latest`.
       type: string
+    always-pull:
+      description: |
+        Explicitly pull the image before running. Useful if using the
+        `latest` tag. Defaults to `false`.
+
+        Note that "true", "on", and "1" are all acceptable values to
+        enable this option. Any other value is considered synonymous
+        with `false`.
+      type: boolean
     address:
       description: |
         The address of the Vault server to interact with. Should


### PR DESCRIPTION
We currently define `hashicorp/vault:latest` to be the default image
to use for access to a `vault` binary. However, this means that the
first time an agent runs this plugin, whatever the current value of
`latest` is will be the image used for the life of that agent. This
isn't an issue for short-lived agents, but could be a concern with
longer-lived agents.

Here, we add an `always-pull` option to the plugin, which allows users
to have additional control over how the image is resolved. If enabled,
an explicit `docker pull` is performed prior to any `docker run`
operations. This enables users to get the _true_ `latest` image,
regardless of what may have been downloaded by the agent at any point
in the past. It defaults to `false`, and is thus backwards compatible.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
