### PR TITLE
Output the Vault image ID and version for visibility / debugging

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -69,6 +69,10 @@ maybe_pull_image
 
 echo "--- :vault: Login to ${VAULT_ADDR}"
 echo "Using Docker image: ${image}"
+echo "Image ID: $(docker inspect "${image}" --format="{{ index .RepoDigests 0 }}")"
+# Don't bother with a `log_and_run` here; it would just clutter up
+# this information display
+echo "Vault Version: $(vault --version)"
 echo "VAULT_ADDR=${VAULT_ADDR}"
 echo "VAULT_NAMESPACE=${VAULT_NAMESPACE}"
 # TODO: add in the `header_value` as well

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -37,8 +37,11 @@ teardown() {
     [ -n "${VAULT_NAMESPACE}" ]
     unset BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -49,8 +52,11 @@ teardown() {
 @test "VAULT_ADDR is overridden in the presence of an explicitly configured address" {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ADDRESS=override.vault.mycompany.com:8200
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=override.vault.mycompany.com:8200 --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=override.vault.mycompany.com:8200 --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -72,8 +78,11 @@ teardown() {
 @test "VAULT_NAMESPACE is overridden in the presence of an explicitly configured namespace" {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_NAMESPACE=override_namespace
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=override_namespace -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=override_namespace -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -94,8 +103,11 @@ teardown() {
 @test "The image can be overridden" {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE=mycompany/vault
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect mycompany/vault:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -106,8 +118,11 @@ teardown() {
 @test "The image tag can be overridden" {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:v1.2.3"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:v1.2.3 --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -119,8 +134,11 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_IMAGE=mycompany/vault
     export BUILDKITE_PLUGIN_VAULT_LOGIN_TAG=v1.2.3
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:v1.2.3"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- mycompany/vault:v1.2.3 login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect mycompany/vault:v1.2.3 --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -131,8 +149,11 @@ teardown() {
 @test "A queue name with a slash is converted to the proper authentication role name" {
     export BUILDKITE_AGENT_META_DATA_QUEUE=default/testing
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -145,8 +166,11 @@ teardown() {
     export BUILDKITE_AGENT_META_DATA_QUEUE=default/testing
     export BUILDKITE_PLUGIN_VAULT_LOGIN_AUTH_ROLE=monkeypants
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=monkeypants : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=monkeypants : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -155,10 +179,14 @@ teardown() {
 }
 
 @test "Multiple login attempts work" {
+
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 1" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 2" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 1" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 2" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success
@@ -174,10 +202,13 @@ teardown() {
     # Waiting 5 seconds during tests sucks
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_WAIT_SECONDS=1
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 3" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 4" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 5"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 3" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 4" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 5"
 
     run "${PWD}/hooks/environment"
     assert_failure
@@ -194,12 +225,15 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_WAIT_SECONDS=1
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_COUNT=5
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 6" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 7" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 8" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 9" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 10"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 6" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 7" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 8" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 9" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 10"
 
     run "${PWD}/hooks/environment"
     assert_failure
@@ -218,8 +252,11 @@ teardown() {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_WAIT_SECONDS=1
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ATTEMPT_COUNT=1
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : exit 11"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : exit 11"
 
     run "${PWD}/hooks/environment"
     assert_failure
@@ -250,9 +287,12 @@ teardown() {
 @test "always-pull will pull an image before running" {
     export BUILDKITE_PLUGIN_VAULT_LOGIN_ALWAYS_PULL=1
 
+    docker_vault_cmd="run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG}"
     stub docker \
          "pull ${DEFAULT_IMAGE}:${DEFAULT_TAG} : echo 'pulling image'" \
-         "run --init --rm --env=SKIP_SETCAP=true --env=VAULT_ADDR=${VAULT_ADDR} --env=VAULT_NAMESPACE=${VAULT_NAMESPACE} -- ${DEFAULT_IMAGE}:${DEFAULT_TAG} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
+         "inspect ${DEFAULT_IMAGE}:${DEFAULT_TAG} --format='{{ index .RepoDigests 0 }}' : echo 'fake image ID'" \
+         "${docker_vault_cmd} --version : echo 'Vault v6.6.6 (The Secrets Manager of the Beast)'" \
+         "${docker_vault_cmd} login -method=aws -token-only role=default : echo 'THIS_IS_YOUR_VAULT_TOKEN'"
 
     run "${PWD}/hooks/environment"
     assert_success


### PR DESCRIPTION
Rather than simply printing out the name of the Vault image being
used, we now also print the ID of the image, as well as the output of
`vault --version`.

Since the `latest` tag will change over time, it can be good to know
more concretely which image and version of Vault is being used.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
