### PR TITLE
Update `buildkite/plugin-tester` to v3.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-common-variables:
 
 services:
   plugin-tester:
-    image: buildkite/plugin-tester:v2.0.0
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - *read-only-plugin
 


### PR DESCRIPTION
This would have been v3.0.0, but there was a bug in that version that
this test suite triggered.

- https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.1
- https://github.com/buildkite-plugins/bats-mock/pull/8

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
